### PR TITLE
Add `types` member to highlight parameters (also add C and Intercept as languages)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.22)
 project(ltx-highlight-code VERSION 0.1.0 LANGUAGES CXX)
 
 ## ============================================================================
@@ -99,7 +99,7 @@ endif()
 
 ## On Windows, don’t suggest the _s nonsense functions.
 if (WIN32)
-    target_compile_definitions(func PRIVATE
+    target_compile_definitions(options INTERFACE
         _CRT_SECURE_NO_WARNINGS
         _CRT_SECURE_NO_WARNINGS_GLOBALS
         _CRT_NONSTDC_NO_WARNINGS

--- a/src/main.cc
+++ b/src/main.cc
@@ -366,6 +366,103 @@ void highlight_cxx(std::string& text) {
         }
     );
 }
+
+void highlight_c(std::string& text) {
+    static constexpr std::string_view keywords[]{
+        "_Alignas",
+        "_Alignof",
+        "_Atomic",
+        "_BitInt",
+        "_Bool",
+        "_Complex",
+        "_Decimal32",
+        "_Decimal64",
+        "_Decimal128",
+        "_Generic",
+        "_Imaginary",
+        "_Noreturn",
+        "_Pragma",
+        "_Static_assert",
+        "_Thread_local",
+        "#embed",
+        "#error",
+        "#include",
+        "#line",
+        "#pragma",
+        "#warning",
+        "#define",
+        "#undef",
+        "#if",
+        "#ifdef",
+        "#ifndef",
+        "#else",
+        "#elif",
+        "#elifdef",
+        "#elifndef",
+        "#endif",
+        "alignas",
+        "alignof",
+        "asm",
+        "auto",
+        "break",
+        "case",
+        "const",
+        "constexpr",
+        "continue",
+        "default",
+        "do",
+        "else",
+        "enum",
+        "extern",
+        "false",
+        "float",
+        "for",
+        "fortran",
+        "goto",
+        "if",
+        "inline",
+        "NULL",
+        "nullptr",
+        "register",
+        "restrict",
+        "return",
+        "sizeof",
+        "static",
+        "static_assert",
+        "struct",
+        "switch",
+        "thread_local",
+        "true",
+        "typedef",
+        "typeof",
+        "typeof_unqual",
+        "union",
+        "volatile",
+        "while",
+    };
+
+    static constexpr std::string_view types[]{
+        "bool",
+        "char",
+        "double",
+        "float",
+        "int",
+        "long",
+        "short",
+        "signed",
+        "unsigned",
+        "void",
+    };
+
+    highlight(
+        text,
+        highlight_params{
+            .lang_name = "C",
+            .string_delimiters = "'\"",
+            .escape_sequences = "'\"\\nrt",
+            .line_comment_prefix = "//",
+            .keywords = keywords,
+            .types = types,
         }
     );
 }
@@ -449,6 +546,7 @@ int main(int argc, char** argv) {
 
     if (lang == "C++") highlight_cxx(text);
     else if (lang == "Go") highlight_go(text);
+    else if (lang == "C") highlight_c(text);
     else if (lang == "Text") {
     } else die("Unknown language '{}'", lang);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -467,6 +467,43 @@ void highlight_c(std::string& text) {
     );
 }
 
+void highlight_intercept(std::string& text) {
+    static constexpr std::string_view keywords[]{
+        "as",
+        "else",
+        "for",
+        "if",
+        "type",
+        "while",
+    };
+
+    static constexpr std::string_view types[]{
+        "byte",
+        "integer",
+        "s8",
+        "s16",
+        "s32",
+        "s64",
+        "u8",
+        "u16",
+        "u32",
+        "u64",
+        "void",
+    };
+
+    highlight(
+        text,
+        highlight_params{
+            .lang_name = "int",
+            .string_delimiters = "'\"",
+            .escape_sequences = "'\"\\nrtfvaeb",
+            .line_comment_prefix = ";;",
+            .keywords = keywords,
+            .types = types,
+        }
+    );
+}
+
 /// The only thing I can stand less than Go is Go without syntax highlighting.
 void highlight_go(std::string& text) {
     static constexpr std::string_view keywords[]{
@@ -547,6 +584,7 @@ int main(int argc, char** argv) {
     if (lang == "C++") highlight_cxx(text);
     else if (lang == "Go") highlight_go(text);
     else if (lang == "C") highlight_c(text);
+    else if (lang == "int") highlight_intercept(text);
     else if (lang == "Text") {
     } else die("Unknown language '{}'", lang);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -382,7 +382,6 @@ void highlight_go(std::string& text) {
         "case",
         "defer",
         "go",
-        "map",
         "struct",
         "chan",
         "else",
@@ -399,6 +398,13 @@ void highlight_go(std::string& text) {
         "import",
         "return",
         "var",
+        "true",
+        "false",
+        "iota",
+        "nil",
+    };
+
+    static constexpr std::string_view types[]{
         "bool",
         "byte",
         "complex64",
@@ -411,18 +417,16 @@ void highlight_go(std::string& text) {
         "int16",
         "int32",
         "int64",
+        "map",
         "rune",
         "string",
+        "T",
         "uint",
         "uint8",
         "uint16",
         "uint32",
         "uint64",
         "uintptr",
-        "true",
-        "false",
-        "iota",
-        "nil",
     };
 
     highlight(
@@ -433,6 +437,7 @@ void highlight_go(std::string& text) {
             .escape_sequences = "'\"\\nrt",
             .line_comment_prefix = "//",
             .keywords = keywords,
+            .types = types,
         }
     );
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -143,6 +143,7 @@ struct highlight_params {
     std::string_view escape_sequences;
     std::string_view line_comment_prefix;
     std::span<const std::string_view> keywords;
+    std::span<const std::string_view> types;
 };
 
 /// Highlight code in a string.
@@ -160,6 +161,7 @@ void highlight(std::string& text, const highlight_params& params) {
     for (usz i = 0; i < operators.size(); ++i) tr.insert(operators.substr(i, 1), kind::operator_);
     for (auto c : params.string_delimiters) tr.insert(std::string_view(&c, 1), kind::string);
     for (const auto& e : escape_sequences) tr.insert(e, kind::escape_sequence);
+    for (const auto& t : params.types) tr.insert(t, kind::type);
     tr.insert("::", kind::operator_);
     tr.insert("T", kind::type);
     tr.insert(params.line_comment_prefix, kind::comment);

--- a/src/main.cc
+++ b/src/main.cc
@@ -163,7 +163,6 @@ void highlight(std::string& text, const highlight_params& params) {
     for (const auto& e : escape_sequences) tr.insert(e, kind::escape_sequence);
     for (const auto& t : params.types) tr.insert(t, kind::type);
     tr.insert("::", kind::operator_);
-    tr.insert("T", kind::type);
     tr.insert(params.line_comment_prefix, kind::comment);
     tr.finalise();
 
@@ -265,14 +264,9 @@ void highlight_cxx(std::string& text) {
         "auto",
         "bitand",
         "bitor",
-        "bool",
         "break",
         "case",
         "catch",
-        "char",
-        "char8_t",
-        "char16_t",
-        "char32_t",
         "class",
         "compl",
         "concept",
@@ -289,7 +283,6 @@ void highlight_cxx(std::string& text) {
         "default",
         "delete",
         "do",
-        "double",
         "dynamic_cast",
         "else",
         "enum",
@@ -297,14 +290,11 @@ void highlight_cxx(std::string& text) {
         "export",
         "extern",
         "false",
-        "float",
         "for",
         "friend",
         "goto",
         "if",
         "inline",
-        "int",
-        "long",
         "mutable",
         "namespace",
         "new",
@@ -322,8 +312,6 @@ void highlight_cxx(std::string& text) {
         "reinterpret_cast",
         "requires",
         "return",
-        "short",
-        "signed",
         "sizeof",
         "static",
         "static_assert",
@@ -340,15 +328,30 @@ void highlight_cxx(std::string& text) {
         "typeid",
         "typename",
         "union",
-        "unsigned",
         "using",
         "virtual",
-        "void",
         "volatile",
-        "wchar_t",
         "while",
         "xor",
         "xor_eq",
+    };
+
+    static constexpr std::string_view types[]{
+        "bool",
+        "char",
+        "char8_t",
+        "char16_t",
+        "char32_t",
+        "double",
+        "float",
+        "int",
+        "long",
+        "short",
+        "signed",
+        "T",
+        "unsigned",
+        "void",
+        "wchar_t",
     };
 
     highlight(
@@ -359,6 +362,10 @@ void highlight_cxx(std::string& text) {
             .escape_sequences = "'\"\\nrt",
             .line_comment_prefix = "//",
             .keywords = keywords,
+            .types = types,
+        }
+    );
+}
         }
     );
 }


### PR DESCRIPTION
First, the CMakeLists needed altered very slightly to get it working on Windows; not a problem. 

From there, I wanted to make it so that types were highlighted not as keywords, but separately as types; to do this, I've added a new member to the highlight parameters structure: `types`. It's exactly like `keywords` except that it inserts into the trie with the `type` kind vs the `keyword` kind. I then went through C++ and Go and attempted to find all the types that were within the keywords list and move them into the types list (I'm not an expert on Go (or C++ for that matter, hehe) but I do believe to have got them all). **I did not test C++ or Go**, so that is definitely something to do. 

I then added C and Intercept as languages, and they seem to be working great!

![image](https://user-images.githubusercontent.com/69637718/234163684-a5d6a866-d97e-48d8-94e3-40e42162eca7.png)

There is one snag I've ran into; escape sequences within strings (using backslash, like `\n` cause the document not to compile with an "Undefined control sequence" error right after the `\n`.
