### PR TITLE
Rename `int` to `Int` to make case more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In code blocks, all whitespace—especially line-initial whitespace—as well as
 The language name is case-sensitive. The following languages are currently supported:
 - C++
 - C
-- int (Intercept)
+- Int (Intercept)
 - Go
 - Text (plain text, but monospaced and with `_` and other special characters escaped)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In code blocks, all whitespace—especially line-initial whitespace—as well as
 The language name is case-sensitive. The following languages are currently supported:
 - C++
 - C
-- Int (Intercept)
+- Int ([Intercept](https://github.com/LensPlaysGames/Intercept "Intercept Compiler on GitHub"))
 - Go
 - Text (plain text, but monospaced and with `_` and other special characters escaped)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Markdown-style inline code and code blocks in your LaTeX documents.
 
 This package requires a reasonably up-to-date version of XeLaTeX to function properly.
 
-Make sure you pass `--enable-write18` to `xelatex` when compiling your document to 
+Make sure you pass `--enable-write18` to `xelatex` when compiling your document to
 enable syntax highlighting. This allows `xelatex` to run shell commands, which is
 necessary since the highlighting is done by an external program.
 
@@ -29,7 +29,7 @@ To use inline code, surround the code with backticks, like so:
 ```
 Note that special characters such as `&` and `_` are escaped automatically.
 
-To insert a backtick character, use two backticks: ` `` `. Note that this does not work inside of inline code. 
+To insert a backtick character, use two backticks: ` `` `. Note that this does not work inside of inline code.
 
 ### Inline code in other commands
 Code blocks and inline code are rather volatile in that passing them to other
@@ -45,7 +45,7 @@ the code `std::to_string(42)` into a footnote, you would do something like this:
 ```
 
 ### Code blocks
-To use code blocks, surround the code with three backticks, followed by the language name inside 
+To use code blocks, surround the code with three backticks, followed by the language name inside
 square brackets like so:
 ````latex
 ```[C++]
@@ -113,7 +113,7 @@ means that if you want to use LaTeX commands inside inline code or code blocks, 
 define replacements for ` \ `, `{`, and `}`.
 
 To simplify this process, the package provides the commands below, which make it so
-LaTeX treats the supplied character as either ` \ `, `{`, or `}` in inline code and code blocks. You can also call any of 
+LaTeX treats the supplied character as either ` \ `, `{`, or `}` in inline code and code blocks. You can also call any of
 these functions multiple times to set multiple alternative escape characters.
 ```latex
 \MDSetEscapeCharacter{<character>}     %% Sets a replacement for \
@@ -149,14 +149,14 @@ The package exposes the following commands for customisation:
 %% Skip that \parskip is set to inside code blocks. Default: \smallskipamount.
 \MDSetCodeBlockLineSkip{<skip>}
 
-%% The file name that is used for the temporary file that is generated 
+%% The file name that is used for the temporary file that is generated
 %% during compilation. Default: temporary.tex.
 %%
 %% Note: The package will also generate a file with the same name but with
 %% an additional .1 appended. You can delete both files at any time.
 \MDSetTempFileName{<filename>}
 
-%% The (path to the) executable that is used to highlight code blocks. 
+%% The (path to the) executable that is used to highlight code blocks.
 %% Default: ltx-highlight-code
 \MDSetHighlightExe{<executable>}
 
@@ -170,4 +170,4 @@ The package exposes the following commands for customisation:
 
 ### Compatibility
 `` ` `` is made active and will be interpreted as the start of inline code or code block. This
-*will* break constructs such as ``\char`~=13`` in the main document (though not in the preamble). 
+*will* break constructs such as ``\char`~=13`` in the main document (though not in the preamble).

--- a/src/main.cc
+++ b/src/main.cc
@@ -601,7 +601,7 @@ void highlight_intercept(std::string& text) {
     highlight(
         text,
         highlight_params{
-            .lang_name = "int",
+            .lang_name = "Int",
             .string_delimiters = "'\"",
             .escape_sequences = "'\"\\nrtfvaeb",
             .line_comment_prefix = ";;",
@@ -698,7 +698,7 @@ int main(int argc, char** argv) {
     if (lang == "C++") highlight_cxx(text);
     else if (lang == "Go") highlight_go(text);
     else if (lang == "C") highlight_c(text);
-    else if (lang == "int") highlight_intercept(text);
+    else if (lang == "Int") highlight_intercept(text);
     else if (lang == "Source") highlight_source(text);
     else if (lang == "Text") {
     } else die("Unknown language '{}'", lang);


### PR DESCRIPTION
As other languages are capitalised, it makes more sense to also capitalise Intercept.

Truthfully mind-blowing amounts of changes here :Þ